### PR TITLE
CA based on correlation

### DIFF
--- a/flap/select.py
+++ b/flap/select.py
@@ -58,8 +58,17 @@ def select_intervals(object_descr, coordinate=None, exp_id='*', intervals=None, 
                                    In each of the above cases the interval will be 'Length' long around the event.
                                    'Above', 'Below':
                                      The intervals will be where the signal is above or below the threshold. 
+                                   'Correlation':
+                                     Will calculate the correlation between the filtered signal and filtered Gaussians, then
+                                     then perform the same interval selection as above for 'Max-weight' and 'Min-weight'.
+                                     The sign of the treshold determines which one will be: (-) stands for 'Min-weight',
+                                     (+) stands for 'Max-weight'
                            'Start delay', 'End delay': For the Above and Below events the start and end delay of the interval
                                                        in the coordinate units.
+                           'Gaussian sigma': For Correlation events. It can be a float, or an 1D array of floats. It contains 
+                                             the sigma parameters of the Gaussians.
+                           'Int tau': For Correlation events. It is the tau parameter for the integrator filter.
+                           'Diff tau': For Correlation events. It is the tau parameter for the differentiator filter.
                            'Threshold': The threshold for the event.
                            'Thr-type' Threshold type:
                                          'Absolute': Absolute signal value
@@ -149,7 +158,7 @@ def select_intervals(object_descr, coordinate=None, exp_id='*', intervals=None, 
         try:
             ev_type = event['Type']
         except KeyError:
-            raise ValueError("Event type is not set. Use Maximum, Minimum, Max-weight, Min-weight, Above or Below")
+            raise ValueError("Event type is not set. Use Maximum, Minimum, Max-weight, Min-weight, Above, Below or Correlation")
         try:
             ev_thr = event['Threshold']
         except KeyError:
@@ -166,6 +175,20 @@ def select_intervals(object_descr, coordinate=None, exp_id='*', intervals=None, 
             end_delay = event['End delay']
         except KeyError:
             end_delay = 0
+        
+        try:
+            gaussian_sigma = event['Gaussian sigma']
+        except KeyError:
+            gaussian_sigma = 0
+        try:
+            int_tau = event['Int tau']
+        except KeyError:
+            int_tau = 0
+        try:
+            diff_tau = event['Diff tau']
+        except KeyError:
+            diff_tau = 0
+        
     else:
         if (((_options['Select'] == 'Start') or (_options['Select'] == 'End')
              or (_options['Select'] == 'Center'))
@@ -254,70 +277,183 @@ def select_intervals(object_descr, coordinate=None, exp_id='*', intervals=None, 
             fig.canvas.mpl_disconnect(cid_release)
             time.sleep(0.1)
         else:
-            # Getting the data and the coordinate for this interval
-            ind = [0]*len(d.shape)
-            data_act = d.data[sel_int_ind[0][i_int]:sel_int_ind[1][i_int]]
-            ind[select_coord_obj.dimension_list[0]] = slice(sel_int_ind[0][i_int], sel_int_ind[1][i_int])
-            coord_act, cl, ch = coord_obj.data(data_shape=d.shape, index=ind)
-            if (sel_int[0][i_int] > sel_int[1][i_int]):
-                data_act = np.flip(data_act)
-                coord_act = np.flip(coord_act)
-            # Finding indices where the condition switches on and off
-            if ((ev_type == 'Maximum') or (ev_type == 'Max-weight') or (ev_type == 'Above')):
-                cond_on = np.logical_and(data_act[1:] > ev_thr,
-                                         data_act[0:-1] <= ev_thr)
-                cond_off = np.logical_and(data_act[0:-1] > ev_thr,
-                                         data_act[1:] <= ev_thr)
-            elif ((ev_type == 'Minimum') or (ev_type == 'Min-weight') or (ev_type == 'Below')):
-                cond_on = np.logical_and(data_act[1:] < ev_thr,
-                                         data_act[0:-1] >= ev_thr)
-                cond_off = np.logical_and(data_act[0:-1] < ev_thr,
-                                         data_act[1:] >= ev_thr)
+            if(ev_type == "Correlation"):
+                ind = [0]*len(d.shape)
+                t = d.coordinate(coordinate)[0][:]
+                data_act = d.slice_data(slicing={coordinate: flap.Intervals(start=t[sel_int_ind[0][i_int]],
+                                                                 stop=t[sel_int_ind[1][i_int]-1])})
+                dl = None
+                if(type(gaussian_sigma) == np.ndarray):
+                    dl = max(gaussian_sigma)*10
+                elif(type(gaussian_sigma) == float or type(gaussian_sigma) == int):
+                    dl = gaussian_sigma*10
+                else:
+                    raise TypeError("Gaussian sigma should be a float, int, or numpy array.")
+                
+                t0 = data_act.coordinate(coordinate)[0][0]
+                dg = data_act.slice_data(slicing={coordinate: flap.Intervals(start=t0,stop=t0+dl)})
+                res = data_act.coordinate(coordinate)[0][1] - data_act.coordinate(coordinate)[0][0]
+                t = np.linspace(0,dl,int(round(dl/res))+1)
+                mu = dl/2
+                event_types = None
+                
+                if(type(gaussian_sigma) == np.ndarray):
+                    N = len(gaussian_sigma)
+                    event_types = np.zeros((t.shape[0],N))
+                    for i in range(N):
+                        s = gaussian_sigma[i]
+                        event_types[:,i] = np.e**(-(1/2)*((t-mu)/s)**2)
+                        for j in range(event_types.shape[0]):
+                            if(1e-15 > abs(event_types[j,i])):
+                               event_types[j,i] = 0
+                    filtered_events = np.zeros((event_types.shape))
+                    for i in range(N):
+                        dg.data = event_types[:,i]
+                        dg = dg.filter_data(options={'Type':'Diff','Tau':diff_tau})
+                        dg = dg.filter_data(options={'Type':'Int','Tau':int_tau})
+                        filtered_events[:,i] = dg.data
+                        
+                elif(type(gaussian_sigma) == float or type(gaussian_sigma) == int):
+                    event_types = np.zeros((t.shape[0]))
+                    s = gaussian_sigma
+                    event_types = np.e**(-(1/2)*((t-mu)/s)**2)
+                    for j in range(event_types.shape[0]):
+                        if(1e-15 > abs(event_types[j])):
+                            event_types[j] = 0
+                    filtered_events = np.zeros((event_types.shape))
+                    dg.data = event_types
+                    dg = dg.filter_data(options={'Type':'Diff','Tau':diff_tau})
+                    dg = dg.filter_data(options={'Type':'Int','Tau':int_tau})
+                    filtered_events = dg.data
+                    
+                t = data_act.coordinate(coordinate)[0][:]
+                d_f = data_act.filter_data(options={'Type':'Diff','Tau':diff_tau})
+                d_f = d_f.filter_data(options={'Type':'Int','Tau':int_tau})
+                all_found_event = []
+                condition = np.zeros((d_f.data.shape[0]))
+                starttime = []
+                endtime = []
+                if(type(gaussian_sigma) == np.ndarray):
+                    for j in range(len(gaussian_sigma)):
+                        corr = np.correlate(d_f.data,filtered_events[:,j], mode="same")
+                        s = np.sqrt(corr.var())
+                        if(ev_thr > 0):
+                            cond = corr>ev_thr*s
+                        if(0 > ev_thr):
+                            cond = ev_thr*s > corr
+                        condition = condition + cond
+                        
+                    for j in range(condition.shape[0]-1):
+                        if(condition[j+1] > 0.5):
+                            condition[j+1] = True
+                        if(condition[j] == False and condition[j+1] == True):
+                            starttime.append(j+1)
+                        if(condition[j] == True and condition[j+1] == False):
+                            endtime.append(j)
+                            
+                    if(len(starttime) != len(endtime)):
+                        raise ValueError("Number of start and end times not coincide.")
+                            
+                    for j in range(len(endtime)):
+                        all_found_event.append(int(round((endtime[j]+starttime[j])/2)))
+                        
+                elif(type(gaussian_sigma) == float or type(gaussian_sigma) == int):
+                    corr = np.correlate(d_f.data,filtered_events, mode="same")
+                    s = np.sqrt(corr.var())
+                    if(ev_thr > 0):
+                        cond = corr>ev_thr*s
+                    if(0 > ev_thr):
+                        cond = ev_thr*s > corr
+                    condition = condition + cond
+                        
+                    for j in range(condition.shape[0]-1):
+                        if(condition[j+1] > 0.5):
+                            condition[j+1] = True
+                        if(condition[j] == False and condition[j+1] == True):
+                            starttime.append(j+1)
+                        if(condition[j] == True and condition[j+1] == False):
+                            endtime.append(j)
+                            
+                    if(len(starttime) != len(endtime)):
+                        raise ValueError("Number of start and end times not coincide.")
+                            
+                    for j in range(len(endtime)):
+                        all_found_event.append(int(round((endtime[j]+starttime[j])/2)))
+
+                H = len(all_found_event)
+                if(len(all_found_event) > 0):
+                    for i in range(H):
+                        if(t[all_found_event[i]]-length > t0 and max(t) > t[all_found_event[i]]+length):
+                            start_coord.append(t0+res*(all_found_event[i])-length/2)
+                            end_coord.append(t0+res*(all_found_event[i])+length/2)
+                H = len(start_coord)
+                selected_n += H
+                y_coord += [ev_thr*np.sqrt(d_f.data.var())]*H
             else:
-                raise ValueError("Invalid event condition.")
-            ind_on = np.nonzero(cond_on)[0] + 1
-            ind_off = np.nonzero(cond_off)[0]
-            if (ind_on[0] > ind_off[0]):
-                ind_off = ind_off[1:]
-            if (len(ind_on) > len(ind_off)):
-                if (len(ind_on) == 1):
-                    ind_on = np.array([])
+                # Getting the data and the coordinate for this interval
+                ind = [0]*len(d.shape)
+                data_act = d.data[sel_int_ind[0][i_int]:sel_int_ind[1][i_int]]
+                ind[select_coord_obj.dimension_list[0]] = slice(sel_int_ind[0][i_int], sel_int_ind[1][i_int])
+                coord_act, cl, ch = coord_obj.data(data_shape=d.shape, index=ind)
+                if (sel_int[0][i_int] > sel_int[1][i_int]):
+                    data_act = np.flip(data_act)
+                    coord_act = np.flip(coord_act)
+                # Finding indices where the condition switches on and off
+                if ((ev_type == 'Maximum') or (ev_type == 'Max-weight') or (ev_type == 'Above')):
+                    cond_on = np.logical_and(data_act[1:] > ev_thr,
+                                             data_act[0:-1] <= ev_thr)
+                    cond_off = np.logical_and(data_act[0:-1] > ev_thr,
+                                             data_act[1:] <= ev_thr)
+                elif ((ev_type == 'Minimum') or (ev_type == 'Min-weight') or (ev_type == 'Below')):
+                    cond_on = np.logical_and(data_act[1:] < ev_thr,
+                                             data_act[0:-1] >= ev_thr)
+                    cond_off = np.logical_and(data_act[0:-1] < ev_thr,
+                                             data_act[1:] >= ev_thr)
                 else:
-                    ind_on = ind_on[0:-1]
-            if (len(ind_off) > len(ind_on)):
-                if (len(ind_off) == 1):
-                    ind_off = np.array([])
-                else:
-                    ind_off = ind_on[1:]
-            if ((ev_type == 'Above') or (ev_type == 'Below')):
-                start_coord += list(coord_act[ind_on] + start_delay)
-                end_coord += list(coord_act[ind_off] + end_delay)
-                selected_n += len(ind_on)
-                y_coord += [ev_thr]*len(ind_on)
-            else:    
-                for i_event in range(len(ind_on)):
-                    if (ev_type == 'Maximum'):
-                        act_ev_coord = coord_act[np.argmax(data_act[ind_on[i_event]
-                                                                    : ind_off[i_event] + 1
-                                                                    ]
-                                                           ) + ind_on[i_event]
-                                                 ]
-                    elif (ev_type == 'Minimum'):
-                        act_ev_coord = coord_act[np.argmin(data_act[ind_on[i_event]
-                                                                    : ind_off[i_event] + 1
-                                                                    ]
-                                                           ) + ind_on[i_event]
-                                                 ]
-                    elif ((ev_type == 'Max-weight') or (ev_type == 'Min-weight')):
-                        act_ev_coord = np.sum(data_act[ind_on[i_event] : ind_off[i_event] + 1]
-                                              * coord_act[ind_on[i_event] : ind_off[i_event] + 1]
-                                              ) / np.sum(data_act[ind_on[i_event] : ind_off[i_event] + 1])
-                    if ((act_ev_coord - length / 2 > coord_act[0])
-                         and (act_ev_coord + length / 2 < coord_act[-1])):
-                        start_coord.append(act_ev_coord - length / 2)
-                        end_coord.append(start_coord[-1] + length)
-                        y_coord.append(ev_thr)
-                        selected_n += 1
+                    raise ValueError("Invalid event condition.")
+                ind_on = np.nonzero(cond_on)[0] + 1
+                ind_off = np.nonzero(cond_off)[0]
+                if (ind_on[0] > ind_off[0]):
+                    ind_off = ind_off[1:]
+                if (len(ind_on) > len(ind_off)):
+                    if (len(ind_on) == 1):
+                        ind_on = np.array([])
+                    else:
+                        ind_on = ind_on[0:-1]
+                if (len(ind_off) > len(ind_on)):
+                    if (len(ind_off) == 1):
+                        ind_off = np.array([])
+                    else:
+                        ind_off = ind_on[1:]
+                if ((ev_type == 'Above') or (ev_type == 'Below')):
+                    start_coord += list(coord_act[ind_on] + start_delay)
+                    end_coord += list(coord_act[ind_off] + end_delay)
+                    selected_n += len(ind_on)
+                    y_coord += [ev_thr]*len(ind_on)
+                else:    
+                    for i_event in range(len(ind_on)):
+                        if (ev_type == 'Maximum'):
+                            act_ev_coord = coord_act[np.argmax(data_act[ind_on[i_event]
+                                                                        : ind_off[i_event] + 1
+                                                                        ]
+                                                               ) + ind_on[i_event]
+                                                     ]
+                        elif (ev_type == 'Minimum'):
+                            act_ev_coord = coord_act[np.argmin(data_act[ind_on[i_event]
+                                                                        : ind_off[i_event] + 1
+                                                                        ]
+                                                               ) + ind_on[i_event]
+                                                     ]
+                        elif ((ev_type == 'Max-weight') or (ev_type == 'Min-weight')):
+                            act_ev_coord = np.sum(data_act[ind_on[i_event] : ind_off[i_event] + 1]
+                                                  * coord_act[ind_on[i_event] : ind_off[i_event] + 1]
+                                                  ) / np.sum(data_act[ind_on[i_event] : ind_off[i_event] + 1])
+                        if ((act_ev_coord - length / 2 > coord_act[0])
+                             and (act_ev_coord + length / 2 < coord_act[-1])):
+                            start_coord.append(act_ev_coord - length / 2)
+                            end_coord.append(start_coord[-1] + length)
+                            y_coord.append(ev_thr)
+                            selected_n += 1
 
     print("Selected "+str(selected_n)+" intervals.")
 

--- a/flap/tests/flap_tests.py
+++ b/flap/tests/flap_tests.py
@@ -21,6 +21,7 @@ import copy
 import time
 import math
 from tkinter import Tk  # Needed for getting the screen size
+import random as ran
 
 # Importing the FLAP
 import flap
@@ -407,6 +408,241 @@ def test_select_multislice():
             flap.plot('TEST-1-1_sliced',
                       slicing={'Interval(Time)':i},
                       axes='Rel. Time in int(Time)')
+            
+def test_select_corr():
+    plt.close('all')
+    print('>>>>>>>> Test select with correlation <<<<<<<<<')
+    flap.delete_data_object('*')
+    
+    #getting a data object with a sin signal
+    d = flap.get_data('TESTDATA',name='TEST-1-1',object_name='TEST-1-1',options={'Length':0.150})
+    d.data = d.data/2 #its intensity was too high, this way the test is more realistic
+    t = d.coordinate("Time")[0][:]
+    
+    print("**** Generating random perturbations.")
+    #parameters of the perturbations:
+    number = 100
+    ts1 = 30
+    ts2 = 60
+    Imax = 0.35
+    Imin = 0.20
+    
+    #adding events
+    timeres = t[1]-t[0]
+    ti = np.zeros((number))
+    I = np.zeros((number))
+    t_indexes = range(1, t.shape[0], 1)
+    ts = np.zeros((number))
+    for i in range(number):
+        ti[i] = ran.choice(t_indexes)
+        I[i] = ran.random()*(Imax-Imin) + Imin
+        ts[i] = ran.random()*(ts2-ts1) + ts1
+    add_light = np.zeros((d.data.shape))
+    for k in range(number):
+        add_light = add_light + I[k]*np.e**(-(1/2)*((t-t[int(ti[k])])/(ts[k]*timeres))**2)
+        
+    #adding events and a mean signal
+    mean_signal = 1.4997363040171798 #W7-X 20181018.026 ABES-11
+    d.data = d.data + add_light + mean_signal
+    
+    #plotting test signal without noise
+    plt.figure()
+    plt.plot(t,d.data)
+    plt.xlabel("Time [s]")
+    plt.ylabel("Test signal without noise [V]")
+    plt.title("Gaussian events")
+    
+    #adding noise
+    a = 0.04378451
+    b = 0.00524973
+    mean_error = a * np.sqrt(mean_signal) + b #valid error for W7-X 20181018.026 ABES-11
+    d.data += np.random.normal(0,mean_error,d.data.shape[0])
+    
+    #plotting test signal with noise
+    plt.figure()
+    plt.plot(t,d.data)
+    plt.xlabel("Time [s]")
+    plt.ylabel("Test signal [V]")
+    plt.title("Gaussian events")
+    
+    #filtering the signal to, then showing its APSD before and after
+    intfilter_tau = 16e-6
+    difffilter_tau = 50e-6
+    d_f = d.filter_data(options={'Type':'Int','Tau':intfilter_tau})
+    d_f = d_f.filter_data(options={'Type':'Diff','Tau':difffilter_tau})
+    
+    plt.figure()
+    p1 = d.apsd(options={'Interval':1, 'Range':[1,1E6],'Res':100})
+    p2 = d_f.apsd(options={'Interval':1, 'Range':[1,1E6],'Res':100})
+    p1.plot(axes="Frequency",options={'Log x': True,
+            'Log y':True, 'Error':False, 'X range':[100,2e5]})
+    p2.plot(axes="Frequency",options={'Log x': True,
+            'Log y':True, 'Error':False, 'X range':[100,2e5]})
+    plt.ylabel("APSD",fontsize=15)
+    plt.xlabel("Frequency [Hz]",fontsize = 15)
+    legend=["before filter","after filter"]
+    plt.legend(legend,fontsize = 12)
+    plt.title("Gaussian events")
+    
+    print("**** Selecting intervals.")
+    #parameters of the selection:
+    Lp = ts1*20*timeres
+    trh = 3
+    N = 5
+    sigmastep = (ts1 + ts2)/N
+    minsigma = ts1
+    sigm = np.arange(minsigma,N*sigmastep+minsigma,sigmastep) * timeres
+    
+    #interval selection, and average event:
+    d_int = flap.select_intervals(d,coordinate='Time',
+                                options={'Select':None,
+                                        'Length':Lp,
+                                        'Event':{'Type':'Correlation',
+                                                  'Threshold':trh,
+                                                  'Thr-type':'sigma',
+                                                  'Gaussian sigma':sigm,
+                                                  'Int tau':intfilter_tau,
+                                                  'Diff tau':difffilter_tau}})
+    mean_event = d.slice_data(slicing={'Time':d_int},
+                              summing ={'Start Time in int(Time)':"Mean"},
+                              options={"Regenerate coordinates":False})
+    
+    #showing the time coordinates of the events:
+    inde = np.zeros((t.shape))
+    for i in range(d_int.data.shape[0]):
+        inde += 1e-10 > abs(d_int.data[i] + Lp/2 - t) 
+    ind=np.nonzero(inde)[0]
+    plt.figure()
+    plt.plot(t,d.data,"+")
+    plt.plot(d_int.data + Lp/2,d.data[ind],"ro")
+    plt.xlabel("Time [s]",fontsize = 15)
+    plt.ylabel("Test signal [V]")
+    legend = ["signal","selected events"]
+    plt.legend(legend,loc = "upper right")
+    plt.title("Gaussian events")
+    
+    #showing the mean event:
+    plt.figure()
+    mean_event.plot(axes = "Rel. Time in int(Time)")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Mean event [V]")
+    plt.title("Gaussian events")
+    
+    
+    #creating a new, noizy signal
+    d2 = flap.get_data('TESTDATA',name='TEST-1-1',object_name='TEST-1-1',options={'Length':0.150})
+    d2.data = d2.data/2 #its intensity was too high, this way the test is more realistic
+    t = d2.coordinate("Time")[0][:]
+    a = 0.04378451
+    b = 0.00524973
+    mean_error = a * np.sqrt(mean_signal) + b #valid error for W7-X 20181018.026 ABES-11
+    d2.data = d2.data + np.random.normal(mean_signal,mean_error,d2.data.shape[0])
+    
+    tau=0.0001
+    E = 0.00005
+    y= (2*E/(3*np.sqrt(np.pi)))*(1+(tau/(t))**2)*(tau/(t)**2)*np.exp(-(tau/(t))**2)
+    plt.figure()
+    plt.plot(t*1e3,y)
+    plt.xlim(-0.0001*1e3,0.002*1e3)
+    plt.xlabel("Time [ms]")
+    plt.ylabel("Signal [V]")
+    plt.title("Theoretical function for type I ELMs in the Free Streaming Model")
+    
+    print("**** Generating random ELMs.")
+    #parameters of the perturbations:
+    taumin = tau/2
+    taumax = tau*2
+    Emax = E*2
+    Emin = E/2
+    number = 50
+    
+    #adding perturbations:
+    ti = np.zeros((number))
+    Es = np.zeros((number))
+    t_indexes = range(1, t.shape[0], 1)
+    taus = np.zeros((number))
+    for i in range(number):
+        ti[i] = ran.choice(t_indexes)
+        Es[i] = ran.random()*(Emax-Emin) + Emin
+        taus[i] = ran.random()*(taumax-taumin) + taumin
+    add_light = np.zeros((d2.data.shape))
+    for k in range(number):
+        y = (2*Es[k]/(3*np.sqrt(np.pi)))*(1+(taus[k]/(t-t[int(ti[k])]))**2)*(taus[k]/(t-t[int(ti[k])])**2)*np.exp(-(taus[k]/(t-t[int(ti[k])]))**2)
+        for i in range(y.shape[0]):
+            if(y.shape[0] > i + int(ti[k])):
+                if(i > ti[k]):
+                    y[i] = y[i]
+                else:
+                    y[i] = 0
+            elif(i + int(ti[k]) >= y.shape[0]):
+                if(i > ti[k]):
+                    y[i] = y[i]
+                else:
+                    y[i] = 0
+        add_light = add_light + y
+    d2.data = d2.data + add_light
+    
+    #howing the raw test signal
+    plt.figure()
+    plt.plot(t,d2.data)
+    plt.xlabel("Time [ms]")
+    plt.ylabel("Signal [V]")
+    plt.title("ELM-like events")
+    
+    #filtering the signal to, then showing its APSD before and after
+    intfilter_tau = 16e-6
+    difffilter_tau = 50e-6
+    d_f = d2.filter_data(options={'Type':'Int','Tau':intfilter_tau})
+    d_f = d_f.filter_data(options={'Type':'Diff','Tau':difffilter_tau})
+    plt.figure()
+    p1 = d2.apsd(options={'Interval':1, 'Range':[1,1E6],'Res':100})
+    p2 = d_f.apsd(options={'Interval':1, 'Range':[1,1E6],'Res':100})
+    p1.plot(axes="Frequency",options={'Log x': True,
+            'Log y':True, 'Error':False, 'X range':[100,2e5]})
+    p2.plot(axes="Frequency",options={'Log x': True,
+            'Log y':True, 'Error':False, 'X range':[100,2e5]})
+    plt.ylabel("APSD",fontsize=15)
+    plt.xlabel("Frequency [Hz]",fontsize = 15)
+    legend=["before filter","after filter"]
+    plt.legend(legend,fontsize = 12)
+    plt.title("ELM-like events")
+    
+    #showing the effect of filter on the events:
+    plt.figure()
+    plt.plot(t,d_f.data)
+    plt.xlabel("Time [ms]")
+    plt.ylabel("Signal after filter [V]")
+    plt.title("ELM-like events")
+    
+    print("**** Selecting intervals.")
+    #parameters of the selection:
+    Lp = ts1*20*timeres
+    trh = 3
+    N = 5
+    sigmastep = (ts1 + ts2)/N
+    minsigma = ts1
+    sigm = np.arange(minsigma,N*sigmastep+minsigma,sigmastep) * timeres
+    
+    #interval selection, and average event:
+    d2_int = flap.select_intervals(d2,coordinate='Time',
+                                options={'Select':None,
+                                        'Length':Lp,
+                                        'Event':{'Type':'Correlation',
+                                                  'Threshold':trh,
+                                                  'Thr-type':'sigma',
+                                                  'Gaussian sigma':sigm,
+                                                  'Int tau':intfilter_tau,
+                                                  'Diff tau':difffilter_tau}})
+    mean_event = d2.slice_data(slicing={'Time':d2_int},
+                              summing ={'Start Time in int(Time)':"Mean"},
+                              options={"Regenerate coordinates":False})
+    
+    #showing the mean event:
+    plt.figure()
+    mean_event.plot(axes = "Rel. Time in int(Time)")
+    plt.xlabel("Time [s]")
+    plt.ylabel("Mean event [V]")
+    plt.title("ELM-like events")
 
 def test_binning():
     print()
@@ -747,7 +983,7 @@ thisdir = os.path.dirname(os.path.realpath(__file__))
 fn = os.path.join(thisdir,"flap_tests.cfg")
 flap.config.read(file_name=fn)
 
-test_all = True
+test_all = False
 
 # Running tests
 plt.close('all')
@@ -792,6 +1028,10 @@ if (False or test_all):
     test_select_multislice()
     show_plot()
     wait_for_key()
+if (True or test_all):
+    test_select_corr()
+    show_plot()
+    wait_for_key()    
 if (False or test_all):
     test_binning()
     show_plot()


### PR DESCRIPTION
I added a new feature to the interval selection in select.py, which can select events on a signal based on its correlation with Gaussian functions characterized by the given parameters. The algorithm filters the signal, and it filters the Gaussians as well, then it calculates the correlation between them. At the end, it defines events, where the correlation is higher than the given treshold.

I also created a detailed test function in the flap_tests.py, where I generated some realistic signals using a 1kHz oscillation, some random placed and sized events, and a valid noise of an ABES channel in Wendelstein 7-X. This 1kHz mode is important, because the main importance of this method is that it can be used in such a frequency range which is close to a plasma mode. For the events, I used Gaussians, and ELM-like perturbations as well, just to show the fact that the algorithm is sufficient for non-Gaussian events as well.